### PR TITLE
chore: Drone Try caching

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,6 +7,17 @@ platform:
   arch: amd64
 
 steps:
+  - name: restore
+    image: plugins/s3-cache
+    settings:
+      pull: true
+      debug: true
+      root: cache.dokku.coreyja
+      access_key:
+        from_secret: CACHE_AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: CACHE_AWS_SECRET_ACCESS_KEY
+      restore: true
   - name: test
     image: ruby:2.3.3
     environment:
@@ -36,8 +47,21 @@ steps:
         - master
       event:
         - push
+  - name: rebuild
+    image: plugins/s3-cache
+    settings:
+      pull: true
+      debug: true
+      root: cache.dokku.coreyja
+      access_key:
+        from_secret: CACHE_AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: CACHE_AWS_SECRET_ACCESS_KEY
+      rebuild: true
+      mount:
+        - vendor/bundle
 ---
 kind: signature
-hmac: adccf6085aa0be8a49d050feac0b77b2643019ffcf2fd98e5e0f0ce9a15f229f
+hmac: f085e6ead2af9489e21c62c9f01742ac8c59ce6ffc7b45aa6242699911cb3f79
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,6 @@ steps:
     image: plugins/s3-cache
     settings:
       pull: true
-      debug: true
       root: cache.dokku.coreyja
       access_key:
         from_secret: CACHE_AWS_ACCESS_KEY_ID
@@ -51,7 +50,7 @@ steps:
     image: plugins/s3-cache
     settings:
       pull: true
-      debug: true
+      flush: true
       root: cache.dokku.coreyja
       access_key:
         from_secret: CACHE_AWS_ACCESS_KEY_ID

--- a/.drone.yml
+++ b/.drone.yml
@@ -58,7 +58,7 @@ steps:
         from_secret: CACHE_AWS_SECRET_ACCESS_KEY
       mount:
         - vendor/bundle
-  - name: rebuild
+  - name: flush-cache
     image: plugins/s3-cache
     settings:
       flush: true
@@ -70,6 +70,6 @@ steps:
         from_secret: CACHE_AWS_SECRET_ACCESS_KEY
 ---
 kind: signature
-hmac: 96925aad2e5ebef79087a4a008fe9d0200b25d581143f539795173ccdb6b784e
+hmac: 8ad8d21fa02ca8c3aa6f18cb4398bf6f381eff4969c9d071b2166ce41f60b2c0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,12 +11,12 @@ steps:
     image: plugins/s3-cache
     settings:
       pull: true
+      restore: true
       root: cache.dokku.coreyja
       access_key:
         from_secret: CACHE_AWS_ACCESS_KEY_ID
       secret_key:
         from_secret: CACHE_AWS_SECRET_ACCESS_KEY
-      restore: true
   - name: test
     image: ruby:2.3.3
     environment:
@@ -50,17 +50,26 @@ steps:
     image: plugins/s3-cache
     settings:
       pull: true
-      flush: true
+      rebuild: true
       root: cache.dokku.coreyja
       access_key:
         from_secret: CACHE_AWS_ACCESS_KEY_ID
       secret_key:
         from_secret: CACHE_AWS_SECRET_ACCESS_KEY
-      rebuild: true
       mount:
         - vendor/bundle
+  - name: rebuild
+    image: plugins/s3-cache
+    settings:
+      flush: true
+      flush_age: 30
+      root: cache.dokku.coreyja
+      access_key:
+        from_secret: CACHE_AWS_ACCESS_KEY_ID
+      secret_key:
+        from_secret: CACHE_AWS_SECRET_ACCESS_KEY
 ---
 kind: signature
-hmac: bb947fdadb844a5ec0e1f7379816d68a4b75ef51b73d3313d06f93bc8d55b802
+hmac: 96925aad2e5ebef79087a4a008fe9d0200b25d581143f539795173ccdb6b784e
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -61,6 +61,6 @@ steps:
         - vendor/bundle
 ---
 kind: signature
-hmac: f085e6ead2af9489e21c62c9f01742ac8c59ce6ffc7b45aa6242699911cb3f79
+hmac: bb947fdadb844a5ec0e1f7379816d68a4b75ef51b73d3313d06f93bc8d55b802
 
 ...


### PR DESCRIPTION
This uses the official Drone S3 Caching plugin

It works pretty well, but it doesn't do caching exactly how I would like. One of the big issues is that it only caches by branch, without support for lockfiles, or arbitrary (runtime decided) cache keys.

So I think this will work for now, but in the future I think I want to write my own plugin to replace this. But for now I think this will be better than nothing!