### PR TITLE
Change nofollower to noopener

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -62,7 +62,7 @@ module.exports = {
             resolve: "gatsby-remark-external-links",
             options: {
               target: "_blank",
-              rel: "nofollow"
+              rel: "noopener"
             }
           }
         ]


### PR DESCRIPTION
This is to fix an issue that Lighthouse brought up. I was linking
externally with an unsafe `rel` so I fixed it